### PR TITLE
Update ServiceCollectionExtensions.cs

### DIFF
--- a/src/AwesomeCMSCore/AwesomeCMSCore/Extension/ServiceCollectionExtensions.cs
+++ b/src/AwesomeCMSCore/AwesomeCMSCore/Extension/ServiceCollectionExtensions.cs
@@ -231,6 +231,7 @@ namespace AwesomeCMSCore.Extension
                     "text/json",
                     // Custom
                     "image/svg+xml",
+                    "font/font-woff2",
                     "application/font-woff2",
                     "application/font-woff",
                     "application/font-ttf",


### PR DESCRIPTION
Adding the desired MIME type to correctly __GZIP__ encode the header with `Content-Encoding: font-woff2`. Addresses the issue: https://github.com/IEvangelist/IEvangelist.AspNetCore.Optimization/issues/1